### PR TITLE
Fixed controller instantiation in tests

### DIFF
--- a/UnitTests/Controllers/AbestosControllerTests.cs
+++ b/UnitTests/Controllers/AbestosControllerTests.cs
@@ -13,11 +13,13 @@ namespace UnitTests
 {
     public class AbestosControllerTests
     {
-        Mock<ILoggerAdapter<AsbestosActions>> fakeLogger;
+        Mock<ILoggerAdapter<AsbestosActions>> fakeActionsLogger;
+        Mock<ILoggerAdapter<AsbestosController>> fakeControllerLogger;
 
         public AbestosControllerTests()
         {
-            fakeLogger = new Mock<ILoggerAdapter<AsbestosActions>>();
+            fakeActionsLogger = new Mock<ILoggerAdapter<AsbestosActions>>();
+            fakeControllerLogger = new Mock<ILoggerAdapter<AsbestosController>>();
         }
 
         [Fact]
@@ -33,7 +35,8 @@ namespace UnitTests
                 .Setup(m => m.GetInspection(It.IsAny<string>()))
                 .Returns(Task.FromResult<IEnumerable<Inspection>>(fakeResponse));
 
-            var controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            var controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                    fakeActionsLogger.Object);
 
             var response = await controller.GetInspection("12345678");
             Assert.Equal(200, response.StatusCode);
@@ -53,7 +56,8 @@ namespace UnitTests
                 .Setup(m => m.GetInspection(It.IsAny<string>()))
                 .Returns(Task.FromResult<IEnumerable<Inspection>>(fakeResponse));
 
-            var controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            var controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                    fakeActionsLogger.Object);
             var response = await controller.GetInspection(propertyId);
 
             Assert.Equal(400, response.StatusCode);
@@ -68,7 +72,8 @@ namespace UnitTests
                 .Setup(m => m.GetInspection(It.IsAny<string>()))
                 .Returns(Task.FromResult<IEnumerable<Inspection>>(fakeResponse));
 
-            var controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            var controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                    fakeActionsLogger.Object);
             var response = await controller.GetInspection("00000000");
 
             Assert.Equal(404, response.StatusCode);
@@ -91,7 +96,8 @@ namespace UnitTests
                 .Setup(m => m.GetInspection(It.IsAny<string>()))
                 .Returns(Task.FromResult<IEnumerable<Inspection>>(fakeResponse));
 
-            AsbestosController controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            AsbestosController controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                                   fakeActionsLogger.Object);
             var response = JObject.FromObject((await controller.GetInspection("12345678")).Value);
 
             var responseId = response["results"][0]["Id"];
@@ -110,7 +116,8 @@ namespace UnitTests
         public async Task return_error_message_if_inspectionid_is_not_valid(string propertyId)
         {
             var fakeAsbestosService = new Mock<IAsbestosService>();
-            var controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            var controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                    fakeActionsLogger.Object);
 
             var response = JObject.FromObject((await controller.GetInspection(propertyId)).Value);
             var userMessage = response["errors"].First["userMessage"].ToString();
@@ -132,7 +139,8 @@ namespace UnitTests
         public async Task response_has_the_valid_format_if_request_unsuccessful(string propertyId)
         {
             var fakeAsbestosService = new Mock<IAsbestosService>();
-            var controller = new AsbestosController(fakeAsbestosService.Object, fakeLogger.Object);
+            var controller = new AsbestosController(fakeAsbestosService.Object, fakeControllerLogger.Object,
+                                                    fakeActionsLogger.Object);
             var response = JObject.FromObject((await controller.GetInspection(propertyId)).Value);
 
             Assert.NotNull(response["errors"]);


### PR DESCRIPTION
Last commit did change the controller constructor arguments but this was not reflected in the controller tests. I have fixed this.