### PR TITLE
Fix swagger config for aws deployment

### DIFF
--- a/LBHAsbestosAPI/Controllers/DataController.cs
+++ b/LBHAsbestosAPI/Controllers/DataController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace LBHAsbestosAPI.Controllers
 {
-	[Route("api/v1/")]
+	[Route("v1/")]
 	public class DataController : Controller
     {
 	    IAsbestosService _asbestosService;

--- a/LBHAsbestosAPI/Controllers/DocumentController.cs
+++ b/LBHAsbestosAPI/Controllers/DocumentController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace LBHAsbestosAPI.Controllers
 {
-    [Route("api/v1/documents")]
+    [Route("v1/documents")]
     public class DocumentController : Controller
     {
         IAsbestosService _asbestosService;

--- a/LBHAsbestosAPI/Startup.cs
+++ b/LBHAsbestosAPI/Startup.cs
@@ -91,7 +91,7 @@ namespace LBHAsbestosAPI
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint(swaggerEndpoint, "Hackney Repairs API");
+                c.SwaggerEndpoint(swaggerEndpoint, "LBH Abestos API v1");
                 c.RoutePrefix = routePrefix;
             });
            

--- a/LBHAsbestosAPI/Startup.cs
+++ b/LBHAsbestosAPI/Startup.cs
@@ -88,13 +88,24 @@ namespace LBHAsbestosAPI
 
             string routePrefix = Environment.GetEnvironmentVariable("SWAGGER_ROUTE_PREFIX");
             string swaggerEndpoint = Environment.GetEnvironmentVariable("SWAGGER_ENDPOINT");
-            app.UseSwagger();
-            app.UseSwaggerUI(c =>
+            if (routePrefix != null && swaggerEndpoint != null)
             {
-                c.SwaggerEndpoint(swaggerEndpoint, "LBH Abestos API v1");
-                c.RoutePrefix = routePrefix;
-            });
-           
+                app.UseSwagger();
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint(swaggerEndpoint, "LBH Abestos API v1");
+                    c.RoutePrefix = routePrefix;
+                });
+            }
+            else
+            {
+                app.UseSwagger();
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "LBH Abestos API v1");
+                });
+            }
+
             app.UseDeveloperExceptionPage();
         }
     }

--- a/LBHAsbestosAPI/Startup.cs
+++ b/LBHAsbestosAPI/Startup.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Swagger;
 using NLog.Extensions.Logging;
 using NLog.Web;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace LBHAsbestosAPI
 {
@@ -28,8 +30,21 @@ namespace LBHAsbestosAPI
             services.AddMvc();
             services.AddSwaggerGen(c =>
             {
-                var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+                c.AddSecurityDefinition("Token",
+                  new ApiKeyScheme
+                  {
+                      In = "header",
+                      Description = "Your Hackney API Key",
+                      Name = "X-Api-Key",
+                      Type = "apiKey"
+                  });
 
+                c.AddSecurityRequirement(new Dictionary<string, IEnumerable<string>>
+                {
+                    { "Token", Enumerable.Empty<string>() }
+                });
+
+                var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
                 c.SwaggerDoc("v1", new Info
                 {
                     Version = "v1",
@@ -70,14 +85,17 @@ namespace LBHAsbestosAPI
             loggerFactory.AddNLog();
 
             app.UseMvc();
+
+            string routePrefix = Environment.GetEnvironmentVariable("SWAGGER_ROUTE_PREFIX");
+            string swaggerEndpoint = Environment.GetEnvironmentVariable("SWAGGER_ENDPOINT");
             app.UseSwagger();
-            app.UseSwaggerUI( cw =>
+            app.UseSwaggerUI(c =>
             {
-                cw.SwaggerEndpoint("/swagger/v1/swagger.json", "LBH Abestos API v1");
+                c.SwaggerEndpoint(swaggerEndpoint, "Hackney Repairs API");
+                c.RoutePrefix = routePrefix;
             });
-
+           
             app.UseDeveloperExceptionPage();
-
         }
     }
 }


### PR DESCRIPTION
Swagger page was unaccessible on the API deployed on AWS. This has been fixed setting up the relative path of the swagger.json on the swagger settings. 
Authorisation via api-key has also been added to the swagger UI.